### PR TITLE
Add make file and update to gradle 6.6.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+
+# Test task.
+test:
+	./gradlew test
+
+# Build task.
+build:
+	./gradlew build

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-bin.zip
+# distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Adds a make file with the tasks `test` and `build` that allow to test and build the sources from the root `Makefile` by using the tool make. This should fix #14.